### PR TITLE
Refactor/chat history

### DIFF
--- a/src/components/LotteryPage.vue
+++ b/src/components/LotteryPage.vue
@@ -11,9 +11,7 @@ import VirtualLotteryPage from "@/components/VirtualLotteryPage";
 
 export default {
   components: {
-    Tabs,
-    GeneratePage,
-    VirtualLotteryPage
+    Tabs
   },
   data() {
     return {

--- a/src/components/VirtualLotteryPage.vue
+++ b/src/components/VirtualLotteryPage.vue
@@ -43,9 +43,11 @@
       <Chat
         class="outer-chat"
         :chatHistory="chatHistory"
+        :historyPageSize="historyPageSize"
         :usernameAllowed="usernameAllowed"
-        v-on:message="sendMessage"
-        v-on:username="setUsername"
+        @loadMoreHistory="loadMoreHistory"
+        @message="sendMessage"
+        @username="setUsername"
       />
     </div>
     <Vipps class="vipps" :amount="1" />
@@ -74,6 +76,9 @@ export default {
       attendeesFetched: false,
       winnersFetched: false,
       chatHistory: [],
+      historyPage: 0,
+      historyPageSize: 100,
+      lastHistoryPage: false,
       usernameAccepted: false,
       username: null,
       wasDisconnected: false,
@@ -157,6 +162,15 @@ export default {
     },
     sendMessage: function(msg) {
       this.socket.emit("chat", { message: msg });
+    },
+    loadMoreHistory: function() {
+      const { historyPage, historyPageSize } = this;
+      const page = historyPage + 1;
+
+      getChatHistory(page * historyPageSize, historyPageSize).then(messages => {
+        this.chatHistory = messages.concat(this.chatHistory);
+        this.historyPage = page;
+      });
     },
     getWinners: async function() {
       let response = await winners();

--- a/src/ui/Chat.vue
+++ b/src/ui/Chat.vue
@@ -82,12 +82,11 @@ export default {
   },
   mounted() {
     let username = window.localStorage.getItem("username");
-    if (!username) {
-      return;
+    if (username) {
+      this.username = username;
+      this.usernameSet = true;
+      this.$emit("username", username);
     }
-    this.username = username;
-    this.usernameSet = true;
-    this.$emit("username", username);
   },
   methods: {
     pad: function(num) {

--- a/src/ui/Tabs.vue
+++ b/src/ui/Tabs.vue
@@ -10,12 +10,7 @@
       >{{ tab.name }}</div>
     </div>
     <div class="tab-elements">
-      <component
-        v-for="(tab, index) in tabs"
-        :key="index"
-        :is="tab.component"
-        :class="chosenTab == index ? null : 'hide'"
-      />
+      <component :is="tabs[chosenTab].component" />
     </div>
   </div>
 </template>
@@ -53,9 +48,6 @@ export default {
 <style lang="scss" scoped>
 h1 {
   text-align: center;
-}
-.hide {
-  display: none;
 }
 
 .tab-container {


### PR DESCRIPTION
Chat history can now load older chats in pages of size `historyPageSize (default: 100)` [0] and update formatting of the chat message [1].

[0] - button for loading more pages
![Screenshot 2020-06-14 at 13 30 26](https://user-images.githubusercontent.com/2287769/84592322-15351c00-ae45-11ea-9c75-b74f6a76056c.png)

[1] - new message formatting and opaque gradient skirt for top of message container
![Screenshot 2020-06-14 at 13 40 51](https://user-images.githubusercontent.com/2287769/84592319-0f3f3b00-ae45-11ea-95b3-f11045070f7f.png)

