### PR TITLE
Feat/latest lottery

### DIFF
--- a/api/controllers/lotteryController.js
+++ b/api/controllers/lotteryController.js
@@ -139,6 +139,26 @@ const allLotteries = (req, res) => {
     });
 };
 
+const latestLottery = (req, res) => {
+  return lotteryRepository
+    .latestLottery()
+    .then(lottery =>
+      res.send({
+        lottery,
+        message: "Latest lottery.",
+        success: true
+      })
+    )
+    .catch(error => {
+      const { statusCode, message } = error;
+
+      return res.status(statusCode || 500).send({
+        message: message || "Unexpected error occured while fetching all lotteries.",
+        success: false
+      });
+    });
+};
+
 function verifyLotteryPayload(raffles, stolen, wines) {
   return new Promise((resolve, reject) => {
     if (raffles == undefined || !raffles instanceof Array) {
@@ -188,5 +208,6 @@ module.exports = {
   drawWinner,
   archiveLottery,
   lotteryByDate,
-  allLotteries
+  allLotteries,
+  latestLottery
 };

--- a/api/lottery.js
+++ b/api/lottery.js
@@ -130,6 +130,10 @@ const allLotteriesIncludingWinners = async (sort = "asc", yearFilter = undefined
   });
 };
 
+const latestLottery = async () => {
+  return Lottery.findOne().sort({ date: -1 });
+};
+
 const drawWinner = async () => {
   let allContestants = await Attendee.find({ winner: false });
 
@@ -259,5 +263,6 @@ module.exports = {
   archive,
   lotteryByDate,
   allLotteries,
-  allLotteriesIncludingWinners
+  allLotteriesIncludingWinners,
+  latestLottery
 };

--- a/api/router.js
+++ b/api/router.js
@@ -71,6 +71,7 @@ router.delete("/lottery/winner/:id", mustBeAuthenticated, winnerController.delet
 
 router.get("/lottery/draw", mustBeAuthenticated, lotteryController.drawWinner);
 router.post("/lottery/archive", mustBeAuthenticated, lotteryController.archiveLottery);
+router.get("/lottery/latest", lotteryController.latestLottery);
 router.get("/lottery/:epoch", lotteryController.lotteryByDate);
 router.get("/lotteries/", lotteryController.allLotteries);
 


### PR DESCRIPTION
## Changes
New API endpoint for getting latest lottery.

This is used to check if todays lottery already has been submitted. If yes we want to disable sending in again and show dialog explaining how to reset for text weeks lottery.

## Images
Shows how the archive button is disabled and new dialog on button of archive lottery page:
![Screenshot 2021-02-20 at 13 32 14](https://user-images.githubusercontent.com/2287769/108595438-2b09c200-7380-11eb-8cfe-e5970c05fcae.png)
